### PR TITLE
Move the chemistry tool examples in the user docs to Jupyter examples

### DIFF
--- a/doc/user/source/Stoichiometry Calculations — auxi 0.3.1 documentation.ipynb
+++ b/doc/user/source/Stoichiometry Calculations — auxi 0.3.1 documentation.ipynb
@@ -1,0 +1,475 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Stoichiometry Calculations\n",
+    "\n",
+    "Warning\n",
+    "auxi.tools.chemistry.stoichiometry is not yet able to successfully parse compound formulae that contain parentheses. It is therefore suggested that a formula such as “Fe2(SO4)3” rather be expressed as “Fe2S3O12”.\n",
+    "\n",
+    "Calculating Molar Mass\n",
+    "Determining the molar mass of a substance is done countless times in mass and energy balance models and other process models. It usually requires you to create your own little database or list that you look up the values from. Once you have that, you can perform the required calculations. The auxi.tools.chemistry.stoichiometry module provides the molar_mass() function for this purpose.\n",
+    "\n",
+    "Standard Approach\n",
+    "The normal way of getting the molar mass of one or more compounds is as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from auxi.tools.chemistry import stoichiometry\n",
+    "\n",
+    "molarmass_FeO = stoichiometry.molar_mass(\"FeO\")\n",
+    "molarmass_CO2 = stoichiometry.molar_mass(\"CO2\")\n",
+    "molarmass_FeCr2O4 = stoichiometry.molar_mass(\"FeCr2O4\")\n",
+    "\n",
+    "#The result of this should be:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "An example is shown below with its output:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(\"Molar mass of FeO    :\", molarmass_FeO, \"kg/kmol\")\n",
+    "print(\"Molar mass of CO2    :\", molarmass_CO2, \"kg/kmol\")\n",
+    "print(\"Molar mass of FeCr2O4:\", molarmass_FeCr2O4, \"kg/kmol\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Compact Approach\n",
+    "\n",
+    "One of Python's strengths is its ability to make code very compact. You may not always want to use a lengthy \"stoichiometry.molar_mass\" reference to the function. Rather than importing the :py:mod:`~.auxi.tools.chemistry.stoichiometry` module, we can import the :py:func:`~.auxi.tools.chemistry.stoichiometry.molar_mass` function directly, and give it another name. Here is how you can make it short and sweet:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from auxi.tools.chemistry.stoichiometry import molar_mass as mm\n",
+    "\n",
+    "molarmass_FeO = mm(\"FeO\")\n",
+    "\n",
+    "print(\"Molar mass of FeO    :\", molarmass_FeO, \"kg/kmol\")\n",
+    "print(\"Molar mass of CO2    :\", mm(\"CO2\"), \"kg/kmol\")\n",
+    "print(\"Molar mass of FeCr2O4:\", mm(\"FeCr2O4\"), \"kg/kmol\")\n",
+    "\n",
+    "#The code is immedeately shown below:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# More Examples\n",
+    "\n",
+    "Here are some more examples of molar mass calculations:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from auxi.tools.chemistry.stoichiometry import molar_mass as mm\n",
+    "\n",
+    "def print_molar_mass(compound):\n",
+    "    print(\"Molar mass of\", compound, \"is\", mm(compound), \"kg/kmol.\")\n",
+    "\n",
+    "print_molar_mass(\"FeO1.5\")\n",
+    "print_molar_mass(\"Fe2O3\")\n",
+    "print_molar_mass(\"FeOTiO2\")\n",
+    "print_molar_mass(\"FeTiO3\")\n",
+    "print_molar_mass(\"Fe2(CO3)3\")\n",
+    "print_molar_mass(\"Fe2C3O9\")\n",
+    "print_molar_mass(\"H2O\")\n",
+    "print_molar_mass(\"H\")\n",
+    "print_molar_mass(\"He\")\n",
+    "print_molar_mass(\"Au\")\n",
+    "\n",
+    "#And the results are:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Calculating Compound Amount\n",
+    "\n",
+    "Sometimes you need to convert the mass of a compound (kg) to the equivalent amount (kmol). The :py:mod:`~.auxi.tools.chemistry.stoichiometry` module provides the :py:func:`~.auxi.tools.chemistry.stoichiometry.amount` function to do this.\n",
+    "\n",
+    "The amount is calculated as follows:\n",
+    "\n",
+    "n_{\\text{compound}} = \\frac{m_{\\text{compound}}}{mm_{\\text{compound}}}\n",
+    "where\n",
+    "\n",
+    " n_{\\text{compound}} is the compound amount in kmol.\n",
+    " m_{\\text{compound}} is the compound mass in kg.\n",
+    " mm_{\\text{compound}} is the compound molar mass in kg/kmol.\n",
+    "Standard Approach\n",
+    "\n",
+    "The normal way of calculating the amount of a compound is as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from auxi.tools.chemistry import stoichiometry\n",
+    "\n",
+    "m_FeO = 10.0\n",
+    "n_FeO = stoichiometry.amount(\"FeO\", m_FeO)\n",
+    "print(\"There is\", n_FeO, \"kmol of FeO in\", m_FeO , \"kg of the compound.\")\n",
+    "\n",
+    "m_CO2 = 12.3\n",
+    "n_CO2 = stoichiometry.amount(\"CO2\", m_CO2)\n",
+    "print(\"There is\", n_CO2, \"kmol of CO2 in\", m_CO2 , \"kg of the compound.\")\n",
+    "\n",
+    "m_FeCr2O4 = 453.0\n",
+    "n_FeCr2O4 = stoichiometry.amount(\"FeCr2O4\", m_FeCr2O4)\n",
+    "print(\"There is\", n_FeCr2O4, \"kmol of FeCr2O4 in\",\n",
+    "      m_FeCr2O4 , \"kg of the compound.\")\n",
+    "\n",
+    "#The result of this should be:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Compact Approach\n",
+    "\n",
+    "To make the code more compact, we can import the function instead of the module and get the same result like this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from auxi.tools.chemistry.stoichiometry import amount\n",
+    "\n",
+    "m_FeO = 10.0\n",
+    "n_FeO = amount(\"FeO\", m_FeO)\n",
+    "print(\"There is\", n_FeO, \"kmol of FeO in\", m_FeO , \"kg of the compound.\")\n",
+    "\n",
+    "m_CO2 = 12.3\n",
+    "n_CO2 = amount(\"CO2\", m_CO2)\n",
+    "print(\"There is\", n_CO2, \"kmol of CO2 in\", m_CO2 , \"kg of the compound.\")\n",
+    "\n",
+    "m_FeCr2O4 = 453.0\n",
+    "n_FeCr2O4 = amount(\"FeCr2O4\", m_FeCr2O4)\n",
+    "print(\"There is\", n_FeCr2O4, \"kmol of FeCr2O4 in\",\n",
+    "      m_FeCr2O4 , \"kg of the compound.\")\n",
+    "\n",
+    "#The result is still the same:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Calculating Compound Mass\n",
+    "\n",
+    "You often have the amount (kmol) of a compound and then need to calculate its mass. The :py:mod:`~.auxi.tools.chemistry.stoichiometry` module provides the :py:func:`~.auxi.tools.chemistry.stoichiometry.mass` function for this. The mass is calculate with this formula:\n",
+    "\n",
+    "m_{\\text{compound}} = n_{\\text{compound}} \\cdot mm_{\\text{compound}}\n",
+    "where\n",
+    "\n",
+    " m_{\\text{compound}} is the compound mass in kg.\n",
+    " n_{\\text{compound}} is the compound amount in kmol.\n",
+    " mm_{\\text{compound}} is the compound molar mass in kg/kmol.\n",
+    "From this point forward the standard and compact approaches are not both demonstrated. Only the standard method, which imports the module, is used below since it is more explicit:\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from auxi.tools.chemistry import stoichiometry\n",
+    "\n",
+    "n_FeO = 10.0\n",
+    "m_FeO = stoichiometry.mass(\"FeO\", n_FeO)\n",
+    "print(\"There is\", m_FeO, \"kg of FeO in\", n_FeO , \"kmol of the compound.\")\n",
+    "\n",
+    "m_CO2 = 12.3\n",
+    "n_CO2 = stoichiometry.mass(\"CO2\", m_CO2)\n",
+    "print(\"There is\", m_CO2, \"kg of CO2 in\", n_CO2 , \"kmol of the compound.\")\n",
+    "\n",
+    "m_FeCr2O4 = 453.0\n",
+    "n_FeCr2O4 = stoichiometry.mass(\"FeCr2O4\", m_FeCr2O4)\n",
+    "print(\"There is\", m_FeCr2O4, \"kg of FeCr2O4 in\",\n",
+    "      n_FeCr2O4 , \"kmol of the compound.\")\n",
+    "\n",
+    "#The restuls are:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Identifying Elements in Compounds\n",
+    "\n",
+    "The list of elements present in one or more compounds can be used when calculating element balances. Determining this list is often done manually. :py:mod:`~.auxi.tools.chemistry.stoichiometry` has the :py:func:`~.auxi.tools.chemistry.stoichiometry.elements` function to automate this task. This is how you use it:\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from auxi.tools.chemistry import stoichiometry\n",
+    "\n",
+    "elements_Fe2O3 = stoichiometry.elements([\"Fe2O3\"])\n",
+    "print(\"Fe2O3 contains these elements:\", elements_Fe2O3)\n",
+    "\n",
+    "elements_CO2 = stoichiometry.elements([\"CO2\"])\n",
+    "print(\"CO2 contains these elements:\", elements_CO2)\n",
+    "\n",
+    "elements_Fe2Cr2O4 = stoichiometry.elements([\"Fe2Cr2O4\"])\n",
+    "print(\"Fe2Cr2O4 contains these elements:\", elements_Fe2Cr2O4)\n",
+    "\n",
+    "elements_Al2S3O12 = stoichiometry.elements([\"Al2(SO4)3\"])\n",
+    "print(\"Al2(SO4)3 contains these elements:\", elements_Al2S3O12)\n",
+    "\n",
+    "elements_all = stoichiometry.elements([\"Fe2O3\", \"CO2\", \"Fe2Cr2O4\", \"Al2(SO4)3\"])\n",
+    "print(\"Fe2O3, CO2, Fe2Cr2O4 and Al2(SO4)3 contain these elements:\",\n",
+    "      elements_all)\n",
+    "\n",
+    "#Here are the results:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Calculating Stoichiometry Coefficients\n",
+    "\n",
+    "The :py:func:`~.auxi.tools.chemistry.stoichiometry.stoichiometry_coefficient` and :py:func:`~.auxi.tools.chemistry.stoichiometry.stoichiometry_coefficients` functions in :py:mod:`~.auxi.tools.chemistry.stoichiometry` determine the stoichiometry coefficients of elements in chemical compounds automatically. If we are only interested in the coefficient for a single element, we use :py:func:`~.auxi.tools.chemistry.stoichiometry.stoichiometry_coefficient` like this:\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from auxi.tools.chemistry import stoichiometry\n",
+    "\n",
+    "coeff_Fe2O3_Fe = stoichiometry.stoichiometry_coefficient(\"Fe2O3\", \"Fe\")\n",
+    "print(\"Stoichiometry coefficient of Fe in Fe2O3:\", coeff_Fe2O3_Fe)\n",
+    "\n",
+    "coeff_Fe2O3_O = stoichiometry.stoichiometry_coefficient(\"Fe2O3\", \"O\")\n",
+    "print(\"Stoichiometry coefficient of O in Fe2O3:\", coeff_Fe2O3_O)\n",
+    "\n",
+    "coeff_Fe2O3_C = stoichiometry.stoichiometry_coefficient(\"Fe2O3\", \"C\")\n",
+    "print(\"Stoichiometry coefficient of C in Fe2O3:\", coeff_Fe2O3_C)\n",
+    "\n",
+    "#The results are:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can determine the coefficients for a list of elements using the :py:func:`~.auxi.tools.chemistry.stoichiometry.stoichiometry_coefficients` function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from auxi.tools.chemistry import stoichiometry\n",
+    "\n",
+    "elements = [\"Fe\", \"O\", \"C\", \"Ar\"]\n",
+    "st_Fe2O3 = stoichiometry.stoichiometry_coefficients(\"Fe2O3\", elements)\n",
+    "print(\"Stoichiometry coefficient of\", elements, \"in Fe2O3:\",\n",
+    "      st_Fe2O3)\n",
+    "\n",
+    "elements = [\"Al\", \"Ca\", \"Fe\", \"Si\", \"O\", \"C\", \"H\"]\n",
+    "st_Lawsonite = stoichiometry.stoichiometry_coefficients(\"CaAl2Si2O7O2H2H2O\",\n",
+    "                                                 elements)\n",
+    "print(\"Stoichiometry coefficient of\", elements,\n",
+    "      \"in Lawsonite (CaAl2(Si2O7)(OH)2·H2O):\", st_Lawsonite)\n",
+    "\n",
+    "#This produces these results:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Calculating Element Mass Fractions\n",
+    "\n",
+    "Another two useful tools in the calculation of element balances are the :py:func:`~.auxi.tools.chemistry.stoichiometry.element_mass_fraction` and :py:func:`~.auxi.tools.chemistry.stoichiometry.element_mass_fractions` functions in :py:mod:`~.auxi.tools.chemistry.stoichiometry`. They are similar to the stoichiometry coefficient functions, but calculate the mass fraction of an element or list of elements in a chemical compound. The calculations are done with the following equation:\n",
+    "\n",
+    "y_{\\text{compound,element}} = \\frac{n_{\\text{compound,element}} \\cdot mm_{\\text{element}}}{mm_{\\text{compound}}}\n",
+    "where\n",
+    "\n",
+    " y_{\\text{compound,element}} is the mass fraction of the specified element in the compound.\n",
+    " n_{\\text{compound,element}} is the stoichiometry coefficient of the specified element in the compound.\n",
+    " mm_{\\text{element}} is the element's molar mass in kg/kmol.\n",
+    " mm_{\\text{compound}} is the compound's molar mass in kg/kmol.\n",
+    "For determining the mass fraction of a single element we can use :py:func:`~.auxi.tools.chemistry.stoichiometry.element_mass_fraction` as follows:\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from auxi.tools.chemistry import stoichiometry\n",
+    "\n",
+    "y_Fe2O3_Fe = stoichiometry.element_mass_fraction(\"Fe2O3\", \"Fe\")\n",
+    "print(\"Mass fraction of Fe in Fe2O3:\", y_Fe2O3_Fe)\n",
+    "\n",
+    "y_Fe2O3_O = stoichiometry.element_mass_fraction(\"Fe2O3\", \"O\")\n",
+    "print(\"Mass fraction of O in Fe2O3:\", y_Fe2O3_O)\n",
+    "\n",
+    "y_Fe2O3_C = stoichiometry.element_mass_fraction(\"Fe2O3\", \"C\")\n",
+    "print(\"Mass fraction of C in Fe2O3:\", y_Fe2O3_C)\n",
+    "#This produces these results:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from auxi.tools.chemistry import stoichiometry\n",
+    "\n",
+    "elements = [\"Fe\", \"O\", \"C\", \"Ar\"]\n",
+    "y_Fe2O3 = stoichiometry.element_mass_fractions(\"Fe2O3\", elements)\n",
+    "print(\"Mass fractions of\", elements, \"in Fe2O3:\", y_Fe2O3)\n",
+    "\n",
+    "elements = [\"Al\", \"Ca\", \"Fe\", \"Si\", \"O\", \"C\", \"H\"]\n",
+    "y_Lawsonite = stoichiometry.element_mass_fractions(\"CaAl2Si2O7O2H2H2O\", elements)\n",
+    "print(\"Mass fractions of\", elements,\n",
+    "      \"in Lawsonite (CaAl2(Si2O7)(OH)2·H2O):\",\n",
+    "      y_Lawsonite)\n",
+    "\n",
+    "#This results in:\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Converting Compounds\n",
+    "\n",
+    "Sometimes it is needed to convert the mass of one compound to an equivalent mass of another compound. For example, how much Fe will I get when I reduce a certain mass of Fe2O3? :py:mod:`~.auxi.tools.chemistry.stoichiometry` has the :py:func:`~.auxi.tools.chemistry.stoichiometry.convert_compound` function to help out. The function calculates the result as follows:\n",
+    "\n",
+    "m_{\\text{target}} = m_{\\text{source}} \\cdot \\frac{y_{\\text{source,element}}}{y_{\\text{target,element}}}\n",
+    "where\n",
+    "\n",
+    " m_{\\text{target}} is the target compound mass in kg.\n",
+    " m_{\\text{source}} is the source compound mass in kg.\n",
+    " y_{\\text{target,element}} is the mass fraction of the specified base element in the target compound.\n",
+    " y_{\\text{source,element}} is the mass fraction of the specified base element in the source compound.\n",
+    "Here are some simple examples of how to use :py:func:`~.auxi.tools.chemistry.stoichiometry.convert_compound`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from auxi.tools.chemistry import stoichiometry\n",
+    "\n",
+    "m_Fe2O3 = 10.0\n",
+    "m_Fe = stoichiometry.convert_compound(m_Fe2O3, \"Fe2O3\", \"Fe\", \"Fe\")\n",
+    "print(\"From\", m_Fe2O3, \"kg of Fe2O3,\", m_Fe ,\n",
+    "      \"kg of Fe can be produced.\")\n",
+    "\n",
+    "m_Fe = 10.0\n",
+    "m_Fe2O3 = stoichiometry.convert_compound(m_Fe, \"Fe\", \"Fe2O3\", \"Fe\")\n",
+    "print(\"When\", m_Fe, \"kg of Fe is oxidised completely,\", m_Fe2O3 ,\n",
+    "      \"kg of Fe2O3 will be produced.\")\n",
+    "\n",
+    "#The results are:"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python [Root]",
+   "language": "python",
+   "name": "Python [Root]"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/doc/user/source/thermochemistry calculations __auxi 0.3.1.ipynb
+++ b/doc/user/source/thermochemistry calculations __auxi 0.3.1.ipynb
@@ -1,0 +1,295 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Thermochemical Calculations\n",
+    "\n",
+    "Preparing Thermochemical Data\n",
+    "\n",
+    "The :py:mod:`auxi.tools.chemistry.thermochemistry` module provides a number of useful functions for doing thermochemical calculations that would otherwise have been quite cumbersome to do. To make these calculations possible, some thermochemical data is needed. The :py:mod:`auxi` distribution package currently contains data for around 80 compounds. This may, however, not be sufficient for your process calculations. FactSage data can be converted into auxi thermochemical data using the :py:func:`~.auxi.tools.chemistry.thermochemistry.convert_fact_file_to_auxi_thermo_file` function.\n",
+    "\n",
+    "To prepare your own compound data files with FactSage, follow these steps:\n",
+    "\n",
+    "Open FactSage.\n",
+    "Click on the \"View Data\" button.\n",
+    "Select the \"Compound\" option, NOT \"Solution\".\n",
+    "Select the database that you want to use. \"FactPS\" should be OK.\n",
+    "Type the formula of the compound you need in the box at the bottom.\n",
+    "Click OK.\n",
+    "Click on the \"Cp(T)\" tab.\n",
+    "Select \"File\" from the menu and then \"Save As ...\".\n",
+    "Select the folder where you want to store all your thermochemical data files.\n",
+    "The filename must have a specific format. Taking \"Ar\" as an example, use \"Compound_Ar.txt\" for the file name.\n",
+    "Click \"Save\".\n",
+    "You will have to repeat this procedure for all the compounds that you need to include in your calculations.\n",
+    "\n",
+    "To convert the factsage file to an auxi thermochemical file use the following code:\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "ename": "AttributeError",
+     "evalue": "module 'auxi.tools.chemistry.thermochemistry' has no attribute 'convert_fact_file_to_auxi_thermo_file'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[1;32m<ipython-input-1-a2bfe7a0e6fe>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m()\u001b[0m\n\u001b[0;32m      1\u001b[0m \u001b[1;32mfrom\u001b[0m \u001b[0mauxi\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mtools\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mchemistry\u001b[0m \u001b[1;32mimport\u001b[0m \u001b[0mthermochemistry\u001b[0m \u001b[1;32mas\u001b[0m \u001b[0mthermo\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      2\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m----> 3\u001b[1;33m \u001b[0mthermo\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mconvert_fact_file_to_auxi_thermo_file\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m\"path/to/factsage_file\"\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;34m\"path/to/new_auxi_thermo_file\"\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[1;31mAttributeError\u001b[0m: module 'auxi.tools.chemistry.thermochemistry' has no attribute 'convert_fact_file_to_auxi_thermo_file'"
+     ]
+    }
+   ],
+   "source": [
+    "from auxi.tools.chemistry import thermochemistry as thermo\n",
+    "\n",
+    "thermo.convert_fact_file_to_auxi_thermo_file(\"path/to/factsage_file\", \"path/to/new_auxi_thermo_file\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Loading Thermochemical Data\n",
+    "If you are going to use the default set of data provided with auxi, you do not need to do anything. The entire data set will be available by default. You can obtain a list of all the compounds and their phases by using the following code:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from auxi.tools.chemistry import thermochemistry as thermo\n",
+    "\n",
+    "thermo.list_compounds()\n",
+    "#Here are the first few lines of the result:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "The result lists all the compounds with the phases for which data are available. Taking the compound SiO2 as an example, data are available for eight solid phases (S1 to S8), for the liquid phase and for the gas phase.\n",
+    "\n",
+    "If you have decided to create you own data folder, you can force :py:mod:`auxi` to use the data in that folder. Here is the code for this:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from auxi.tools.chemistry import thermochemistry as thermo\n",
+    "\n",
+    "thermo.load_data('/home/someuser/thermodata')\n",
+    "thermo.list_compounds()\n",
+    "#This example data folder only contains a small selection of files:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "Calculating Heat Capacity\n",
+    "\n",
+    "The :py:func:`~.auxi.tools.chemistry.thermochemistry.Cp` function in the :py:mod:`auxi.tools.chemistry.thermochemistry` module can be used to calculate the heat capacity at constant pressure for a compound. This can be done as follows:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from auxi.tools.chemistry import thermochemistry as thermo\n",
+    "\n",
+    "Cp_H2O = thermo.Cp(\"H2O[L]\", 70.0)\n",
+    "print(\"The Cp of 1 kg of water at 70 °C is\", Cp_H2O, \"kWh/K.\")\n",
+    "\n",
+    "Cp_H2O = thermo.Cp(\"H2O[G]\", 70.0)\n",
+    "print(\"The Cp of 1 kg of water vapour at 70 °C is\", Cp_H2O, \"kWh/K.\")\n",
+    "\n",
+    "m_ZrO2 = 2.34\n",
+    "Cp_ZrO2 = thermo.Cp(\"ZrO2[S1]\", 893.5, m_ZrO2)\n",
+    "print(\"The Cp of 2.34 kg of ZrO2[S1] at 893.5 °C is\", Cp_ZrO2, \"kWh/K.\")\n",
+    "#Here are the results:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The first parameter to the function must specify both the compound's formula and phase. If the phase is not specified it is impossible to calculate a result. The heat capacity of water is clearly significantly different from that of water vapour.\n",
+    "\n",
+    "The last parameter of the :py:func:`~.auxi.tools.chemistry.thermochemistry.Cp` is mass and it is optional. If no value is specified, it is taken to be 1 kg. This was the case for the first two calculations above. A mass of 2.34 kg was specified in the last Cp calculation.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Calculating Enthalpy\n",
+    "\n",
+    "The :py:func:`~.auxi.tools.chemistry.thermochemistry.H` function in :py:mod:`~.auxi.tools.chemistry.thermochemistry` is used to calculate the enthalpy of a compound. This can be done as follows:\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "from auxi.tools.chemistry import thermochemistry as thermo\n",
+    "\n",
+    "H_H2O = thermo.H(\"H2O[L]\", 70.0)\n",
+    "print(\"The enthalpy of 1 kg of water at 70 °C is\", H_H2O, \"kWh.\")\n",
+    "\n",
+    "H_H2O = thermo.H(\"H2O[G]\", 70.0)\n",
+    "print(\"The enthalpy of 1 kg of water vapour at 70 °C is\", H_H2O, \"kWh.\")\n",
+    "\n",
+    "m_ZrO2 = 2.34\n",
+    "H_ZrO2 = thermo.H(\"ZrO2[S1]\", 893.5, m_ZrO2)\n",
+    "print(\"The enthalpy of 2.34 kg of ZrO2[S1] at 893.5 °C is\", H_ZrO2, \"kWh.\")\n",
+    "#Here are the results:\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The parameters to the :py:func:`~.auxi.tools.chemistry.thermochemistry.H` function works the same as that of the :py:func:`~.auxi.tools.chemistry.thermochemistry.Cp` function. Both formula and phase are required in the first parameter, the second is temperature in °C and the third is mass, which is optional with a default value of 1 kg."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Calculating Entropy\n",
+    "\n",
+    "The :py:func:`~.auxi.tools.chemistry.thermochemistry.S` function in :py:mod:`~.auxi.tools.chemistry.thermochemistry` is used to calculate the entropy of a compound. This can be done as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from auxi.tools.chemistry import thermochemistry as thermo\n",
+    "\n",
+    "S_H2O = thermo.S(\"H2O[L]\", 70.0)\n",
+    "print(\"The entropy of 1 kg of water at 70 °C is\", S_H2O, \"kWh/K.\")\n",
+    "\n",
+    "S_H2O = thermo.S(\"H2O[G]\", 70.0)\n",
+    "print(\"The entropy of 1 kg of water vapour at 70 °C is\", S_H2O, \"kWh/K.\")\n",
+    "\n",
+    "m_ZrO2 = 2.34\n",
+    "S_ZrO2 = thermo.S(\"ZrO2[S1]\", 893.5, m_ZrO2)\n",
+    "print(\"The entropy of 2.34 kg of ZrO2[S1] at 893.5 °C is\", S_ZrO2, \"kWh/K.\")\n",
+    "#Here are the results:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "The parameters to the :py:func:`~.auxi.tools.chemistry.thermochemistry.S` function works the same as that of the :py:func:`~.auxi.tools.chemistry.thermochemistry.Cp` function. Both formula and phase are required in the first parameter, the second is temperature in °C and the third is mass, which is optional with a default value of 1 kg.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Calculating Gibbs Free Energy\n",
+    "\n",
+    "The :py:func:`~.auxi.tools.chemistry.thermochemistry.G` function in :py:mod:`~.auxi.tools.chemistry.thermochemistry` is used to calculate the Gibbs free energy of a compound. This can be done as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from auxi.tools.chemistry import thermochemistry as thermo\n",
+    "\n",
+    "G_H2O = thermo.G(\"H2O[L]\", 70.0)\n",
+    "print(\"The Gibbs free energy of 1 kg of water at 70 °C is\", G_H2O,\n",
+    "    \"kWh.\")\n",
+    "\n",
+    "G_H2O = thermo.G(\"H2O[G]\", 70.0)\n",
+    "print(\"The Gibbs free energy of 1 kg of water vapour at 70 °C is\", G_H2O,\n",
+    "    \"kWh.\")\n",
+    "\n",
+    "m_ZrO2 = 2.34\n",
+    "G_ZrO2 = thermo.G(\"ZrO2[S1]\", 893.5, m_ZrO2)\n",
+    "print(\"The Gibbs free energy of 2.34 kg of ZrO2[S1] at 893.5 °C is\", G_ZrO2,\n",
+    "    \"kWh.\")\n",
+    "#Here are the results:\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The parameters to the :py:func:`~.auxi.tools.chemistry.thermochemistry.G` function works the same as that of the :py:func:`~.auxi.tools.chemistry.thermochemistry.Cp` function. Both formula and phase are required in the first parameter, the second is temperature in °C and the third is mass, which is optional with a default value of 1 kg."
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python [Root]",
+   "language": "python",
+   "name": "Python [Root]"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
Background
Improvements have been made to Stoichiometry Calculations.rst and Thermochemistry Calcuations.rst. These improvements include the changing the code from static .rst to a more dynamic .ipynb. Minor challenges have been met, but progress has been made.

Purpose
To upgrade the Stoichiometry Calculations.rst and Thermochemistry Calcuations.rst files into .ipynb file.

Approach
Anaconda 3.5 was downloaded and jupyter was used to create the file attached. Most of the .rst file was changed into either Markdown, Headings or code to allow interaction.
Where technical limitations were met they were displayed as comments(especially putting a markdown between the code and the expected outcomes)

Notes: The structure of the file can be improved by allowing sphinx to do its work of styling the markdown and headings, but the pip install in anaconda did not help.
         : An install of auxi needs to be made in the anaconda environment.